### PR TITLE
security: Remove hardcoded credentials for public release

### DIFF
--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -256,24 +256,42 @@ def has_permission(user: Dict[str, Any], permission: str) -> bool:
     permissions = ROLE_PERMISSIONS.get(role, [])
     return permission in permissions
 
-# Initialize default users for testing
+# Initialize default users for testing (DEVELOPMENT ONLY)
 def initialize_default_users():
-    """Create default users for testing and development."""
+    """Create default users for testing and development.
+
+    WARNING: This function only runs in development mode (ENVIRONMENT != 'production').
+    In production, users should be created through proper registration or admin tools.
+    """
     global user_id_counter
 
+    # Only create default users in development mode
+    environment = os.getenv('ENVIRONMENT', 'development').lower()
+    if environment == 'production':
+        print("ℹ️  Production mode: Skipping default user creation")
+        return
+
     if len(users_db) == 0:
-        print("\n🔐 Initializing default users...")
+        import secrets
+
+        print("\n🔐 Initializing default users (development mode only)...")
+        print("⚠️  WARNING: Default users are for development only. Do not use in production.")
+
+        # Generate random passwords for default users
+        admin_pwd = secrets.token_urlsafe(16)
+        user_pwd = secrets.token_urlsafe(16)
+        viewer_pwd = secrets.token_urlsafe(16)
 
         # Create admin user
         try:
             admin_user = UserCreate(
                 email="admin@example.com",
-                password="admin123",
+                password=admin_pwd,
                 username="Administrator",
                 role=UserRole.ADMIN
             )
             create_user(admin_user)
-            print("  ✓ Admin user created: admin@example.com / admin123")
+            print(f"  ✓ Admin user created: admin@example.com / {admin_pwd}")
         except Exception as e:
             print(f"  ✗ Failed to create admin user: {e}")
 
@@ -281,12 +299,12 @@ def initialize_default_users():
         try:
             regular_user = UserCreate(
                 email="user@example.com",
-                password="user123",
+                password=user_pwd,
                 username="Regular User",
                 role=UserRole.USER
             )
             create_user(regular_user)
-            print("  ✓ Regular user created: user@example.com / user123")
+            print(f"  ✓ Regular user created: user@example.com / {user_pwd}")
         except Exception as e:
             print(f"  ✗ Failed to create regular user: {e}")
 
@@ -294,13 +312,14 @@ def initialize_default_users():
         try:
             viewer_user = UserCreate(
                 email="viewer@example.com",
-                password="viewer123",
+                password=viewer_pwd,
                 username="Viewer User",
                 role=UserRole.VIEWER
             )
             create_user(viewer_user)
-            print("  ✓ Viewer user created: viewer@example.com / viewer123")
+            print(f"  ✓ Viewer user created: viewer@example.com / {viewer_pwd}")
         except Exception as e:
             print(f"  ✗ Failed to create viewer user: {e}")
 
-        print(f"\n📊 Total users: {len(users_db)}\n")
+        print(f"\n📊 Total users: {len(users_db)}")
+        print("📝 Note: Save these credentials - they are randomly generated each startup.\n")

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -11,15 +11,17 @@ from datetime import datetime
 import enum
 import os
 
-# Database URL from environment or default to SQLite for development
-DATABASE_URL = os.getenv(
-    "DATABASE_URL",
-    "postgresql://postgres:postgres@localhost:5432/cloud_manager"
-)
+# Database URL from environment
+# In production, DATABASE_URL must be set. In development, falls back to SQLite.
+DATABASE_URL = os.getenv("DATABASE_URL")
 
-# For SQLite fallback in development
-if not DATABASE_URL.startswith("postgresql"):
+if not DATABASE_URL:
+    # Development fallback: use SQLite (no credentials needed)
     DATABASE_URL = "sqlite:///./cloud_manager.db"
+    print("ℹ️  DATABASE_URL not set, using SQLite for development")
+elif not DATABASE_URL.startswith("postgresql"):
+    # If set but not PostgreSQL, use as-is (could be SQLite path)
+    pass
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/frontend-v3/src/pages/Settings.jsx
+++ b/frontend-v3/src/pages/Settings.jsx
@@ -95,8 +95,9 @@ function Settings() {
 
     localStorage.setItem('cloudCredentials', JSON.stringify(settingsForStorage));
 
-    // Also save to sessionStorage for current session (including secrets)
-    sessionStorage.setItem('cloudCredentials', JSON.stringify(settings));
+    // Note: Secrets are NOT stored in browser storage for security.
+    // They are only held in React state during the current page session.
+    // For production use, credentials should be managed server-side via environment variables.
 
     setSaveStatus('success');
     setSaveMessage('Settings saved successfully! These will be used for your deployments.');
@@ -122,7 +123,6 @@ function Settings() {
     setGcpRegion('');
 
     localStorage.removeItem('cloudCredentials');
-    sessionStorage.removeItem('cloudCredentials');
 
     setSaveStatus('success');
     setSaveMessage('Settings reset! Using default environment credentials.');
@@ -405,9 +405,9 @@ function Settings() {
               <h3 className="text-sm font-medium text-blue-800">Security Notice</h3>
               <div className="mt-2 text-sm text-blue-700">
                 <ul className="list-disc list-inside space-y-1">
-                  <li>Custom credentials are stored in your browser's localStorage/sessionStorage</li>
-                  <li>Secrets (like client secret) are only stored for the current session</li>
-                  <li>For production use, consider using environment variables or a secure secrets manager</li>
+                  <li>Non-sensitive settings (IDs, regions) are stored in localStorage</li>
+                  <li>Secrets (like client secret) are never persisted - they're cleared on page refresh</li>
+                  <li>For production use, configure credentials via environment variables on the server</li>
                   <li>These settings apply to deployments made from this browser only</li>
                 </ul>
               </div>


### PR DESCRIPTION
- Default users now only created in development mode (ENVIRONMENT != 'production')
- Default user passwords are randomly generated at startup instead of hardcoded
- Removed hardcoded PostgreSQL credentials, fallback to SQLite in development
- Removed secrets storage in browser sessionStorage
- Updated security notice in Settings page to reflect new behavior